### PR TITLE
fix(docs): fix on the windows installation script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,7 @@ curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version
 tar.exe xvf .\containerd-windows-amd64.tar.gz
 
 # Copy and configure
-Copy-Item -Path ".\bin\*" -Destination "$Env:ProgramFiles\containerd" -Recurse -Container:$false -Force
+Copy-Item -Path ".\bin" -Destination "$Env:ProgramFiles\containerd" -Recurse -Force
 cd $Env:ProgramFiles\containerd\
 .\containerd.exe config default | Out-File config.toml -Encoding ascii
 


### PR DESCRIPTION
fix #9049

Modify the parameter `-Path` to reference a folder, so `Copy-Item` create the destination folder.
Remove `-Container:$false` that flatten the hierarchy folder.